### PR TITLE
Escape user-supplied or externally defined SQL params.

### DIFF
--- a/NewsletterSubscription.module
+++ b/NewsletterSubscription.module
@@ -125,7 +125,8 @@ class NewsletterSubscription extends WireData implements Module, ConfigurableMod
    * Get user by token
    */
   private function getUserByToken() {
-    $token = $this->sanitizer->text($this->input->get->t);
+    $token = $this->db->escapeStr($this->input->get->t);
+    $userAuthSalt = $this->db->escapeStr($this->config->userAuthSalt);
     $role = $this->roles->get('newsletter');
 
     $select = 'p.id, e.data AS email, p.created FROM pages AS p';
@@ -134,10 +135,10 @@ class NewsletterSubscription extends WireData implements Module, ConfigurableMod
     $where = "r.data = '{$role->id}'";
 
     if ($this->sanitizer->text($this->input->get->a) === 'subscribe') {
-      $addWhere = "sha1(CONCAT(e.data, p.id, '{$this->config->userAuthSalt}')) = '$token'";
+      $addWhere = "sha1(CONCAT(e.data, p.id, '$userAuthSalt')) = '$token'";
       $addWhere .= ' && p.status = ' . Page::statusHidden;
     } else {
-      $addWhere = "sha1(CONCAT(e.data, '{$this->config->userAuthSalt}')) = '$token'";
+      $addWhere = "sha1(CONCAT(e.data, '$userAuthSalt')) = '$token'";
       $addWhere .= ' && p.status = ' . Page::statusOn;
     }
 


### PR DESCRIPTION
The text sanitizer strips HTML tags and newline characters. It does not prepare a string for use in a SQL statement. I also consider  `$this->config->userAuthSalt` as a possibly tainted external input as one never knows what a site owner might put there.
